### PR TITLE
Update ReadWriteDim2.jl usage of Tables.Columns

### DIFF
--- a/src/rwd2_tables.jl
+++ b/src/rwd2_tables.jl
@@ -7,12 +7,12 @@ Materialize any table source input as a `Matrix{Any}`.
 Column names - in Symbol type - are written in first row.
 """
 function matrix2(table)
-    cols = Tables.columns(table)
+    cols = Tables.Columns(table)
     cnames = Tables.columnnames(table)
     nr = Tables.rowcount(cols) + 1
     nc = length(cnames)
     matrix = Matrix{Any}(undef, nr, nc)
-    for (i, col) in enumerate(Tables.Columns(cols))
+    for (i, col) in enumerate(cols)
         matrix[1, i] = cnames[i]
         matrix[2:end, i] = col
     end


### PR DESCRIPTION
From the change in https://github.com/JuliaData/Tables.jl/pull/255, we're considering the fact that Tables.Columns didn't call Tables.columns a bug, so it's being changed and you don't need to call Tables.columns yourself anymore when using Tables.Columns. Luckily, I'm not aware of any table inputs where this actually makes a difference (i.e. a table where Tables.columns(x) !== x), so this shouldn't be very disruptive.